### PR TITLE
Review clippy configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,9 +163,15 @@ cumulus-relay-chain-minimal-node = {git = "https://github.com/zkVerify/zkVerify.
 polkadot-parachain-lib = {git = "https://github.com/zkVerify/zkVerify.git", tag = "0.9.1-0.13.0"}
 
 [workspace.lints.clippy]
-large_enum_variant = "allow"
-too_many_arguments = "allow"
-type_complexity = "allow"
+all = { level = "allow", priority = 0 }                              # Basically, we accept the _perf_ clippy concerns
+correctness = { level = "deny", priority = 1 }                       # But reject all other stuff
+suspicious = { level = "deny", priority = 1 }
+complexity = { level = "deny", priority = 1 }
+style = { level = "warn", priority = 1 }
+# perf = { level = "warn", priority = 1 }                            # We don't care about performace (polkadot also)
+large_enum_variant = { level = "allow", priority = 2 }
+too_many_arguments = { level = "allow", priority = 2 }
+type_complexity = { level = "allow", priority = 2 }
 
 [profile.production]
 codegen-units = 1


### PR DESCRIPTION
Review the default workspace configuration. Rust 1.87.0 spot out a clippy::result-large-err related to perf clippy flavor.