### PR TITLE
Update zkVerify and Polkadot dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "aggregate-rpc"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "aggregate-rpc-runtime-api",
  "jsonrpsee 0.24.9",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aggregate-rpc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "binary-merkle-tree",
  "pallet-aggregate",
@@ -118,7 +118,6 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -131,7 +130,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -644,17 +643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-curve25519"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab653b3eff27100f7dcb06b94785f2fbe0d1230408df55d543ee0ef48cd8760"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
 name = "ark-ec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,18 +1123,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ascii-canvas"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
-dependencies = [
- "term",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -1542,34 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "asynchronous-codec"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
-dependencies = [
- "bytes",
- "futures-sink",
- "futures-util",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -1679,20 +1633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bigdecimal"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
-dependencies = [
- "autocfg",
- "libm",
- "num-bigint",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,12 +1700,6 @@ dependencies = [
  "serde",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "bit-iter"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c95b1159d450fcb44b73b8d7b7b739656061483a585bffe4b7484e617bf55e9"
 
 [[package]]
 name = "bit-set"
@@ -3135,9 +3069,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797249e27522966baae0f95c274ad27383edee4c143811bf1dad228e7688a5c0"
+checksum = "79b0f1c236046a1e501bfab80a73cccba858285fcd12592530d6e02d8b69c854"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -3637,7 +3571,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.22.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3681,7 +3615,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.22.1"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -3780,9 +3714,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "rand_core 0.6.4",
  "rustc_version 0.4.1",
- "serde",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -4038,7 +3970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -4423,15 +4354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4544,7 +4466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5736,16 +5658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-bounded"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
-dependencies = [
- "futures-timer",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,15 +6070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6211,20 +6114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32",
- "rustc_version 0.4.1",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -6407,18 +6296,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hp-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "frame-support",
  "ismp",
@@ -6427,13 +6307,12 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
 name = "hp-groth16"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254 0.4.0",
@@ -6448,13 +6327,12 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime-interface",
- "sp-std",
 ]
 
 [[package]]
 name = "hp-on-proof-verified"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "impl-trait-for-tuples",
  "sp-core",
@@ -6464,14 +6342,13 @@ dependencies = [
 [[package]]
 name = "hp-verifiers"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "hex-literal",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-std",
  "sp-weights",
 ]
 
@@ -7043,7 +6920,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7599,38 +7476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.14.0",
- "lalrpop-util",
- "petgraph 0.7.1",
- "pico-args",
- "regex",
- "regex-syntax 0.8.5",
- "sha3",
- "string_cache",
- "term",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
-dependencies = [
- "regex-automata 0.4.9",
- "rustversion",
-]
-
-[[package]]
 name = "landlock"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7696,7 +7541,7 @@ dependencies = [
  "libp2p-dns 0.40.1",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.44.6",
+ "libp2p-kad",
  "libp2p-mdns 0.44.0",
  "libp2p-metrics",
  "libp2p-noise",
@@ -7884,10 +7729,10 @@ version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
 dependencies = [
- "asynchronous-codec 0.6.2",
+ "asynchronous-codec",
  "either",
  "futures",
- "futures-bounded 0.1.0",
+ "futures-bounded",
  "futures-timer",
  "libp2p-core 0.40.1",
  "libp2p-identity",
@@ -7895,7 +7740,7 @@ dependencies = [
  "log",
  "lru 0.12.5",
  "quick-protobuf",
- "quick-protobuf-codec 0.2.0",
+ "quick-protobuf-codec",
  "smallvec",
  "thiserror 1.0.69",
  "void",
@@ -7926,7 +7771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ea178dabba6dde6ffc260a8e0452ccdc8f79becf544946692fff9d412fc29d"
 dependencies = [
  "arrayvec 0.7.6",
- "asynchronous-codec 0.6.2",
+ "asynchronous-codec",
  "bytes",
  "either",
  "fnv",
@@ -7938,7 +7783,7 @@ dependencies = [
  "libp2p-swarm 0.43.7",
  "log",
  "quick-protobuf",
- "quick-protobuf-codec 0.2.0",
+ "quick-protobuf-codec",
  "rand 0.8.5",
  "sha2 0.10.9",
  "smallvec",
@@ -7946,35 +7791,6 @@ dependencies = [
  "uint 0.9.5",
  "unsigned-varint 0.7.2",
  "void",
-]
-
-[[package]]
-name = "libp2p-kad"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
-dependencies = [
- "arrayvec 0.7.6",
- "asynchronous-codec 0.7.0",
- "bytes",
- "either",
- "fnv",
- "futures",
- "futures-bounded 0.2.4",
- "futures-timer",
- "libp2p-core 0.42.0",
- "libp2p-identity",
- "libp2p-swarm 0.45.1",
- "quick-protobuf",
- "quick-protobuf-codec 0.3.1",
- "rand 0.8.5",
- "sha2 0.10.9",
- "smallvec",
- "thiserror 1.0.69",
- "tracing",
- "uint 0.9.5",
- "void",
- "web-time",
 ]
 
 [[package]]
@@ -8029,7 +7845,7 @@ dependencies = [
  "libp2p-core 0.40.1",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-kad 0.44.6",
+ "libp2p-kad",
  "libp2p-ping",
  "libp2p-swarm 0.43.7",
  "once_cell",
@@ -9161,7 +8977,7 @@ checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 [[package]]
 name = "native"
 version = "0.3.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-bn254-ext",
@@ -9268,12 +9084,6 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -9701,7 +9511,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aggregate"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "binary-merkle-tree",
  "educe",
@@ -9717,7 +9527,6 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -10176,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "pallet-claim"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10186,7 +9995,6 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -10697,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "pallet-fflonk-verifier"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "fflonk_verifier",
  "frame-benchmarking",
@@ -10760,7 +10568,7 @@ dependencies = [
 [[package]]
 name = "pallet-groth16-verifier"
 version = "0.2.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10772,7 +10580,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-std",
 ]
 
 [[package]]
@@ -10793,7 +10600,7 @@ dependencies = [
 [[package]]
 name = "pallet-hyperbridge-aggregations"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives 0.8.25",
@@ -10812,7 +10619,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -11265,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "pallet-plonky2-verifier"
 version = "0.1.1"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "educe",
  "frame-benchmarking",
@@ -11281,7 +11087,6 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-std",
 ]
 
 [[package]]
@@ -11299,25 +11104,6 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
-]
-
-[[package]]
-name = "pallet-proofofsql-verifier"
-version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
-dependencies = [
- "educe",
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "hp-verifiers",
- "log",
- "pallet-verifiers",
- "parity-scale-codec",
- "proof-of-sql-verifier",
- "scale-info",
- "sp-core",
- "sp-std",
 ]
 
 [[package]]
@@ -11404,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "pallet-risc0-verifier"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "ciborium",
  "frame-benchmarking",
@@ -11420,7 +11206,6 @@ dependencies = [
  "risc0-verifier",
  "scale-info",
  "sp-core",
- "sp-std",
 ]
 
 [[package]]
@@ -11494,9 +11279,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "40.2.0"
+version = "40.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e290bcd7f5e1eefcd5eec1e21efa9ac690c6f97e4534aa3831ff78b7d1fbda68"
+checksum = "3529cba7d544becd6b7e1b0c409dccf62b00991a319ea741aaae5511bd3d0fe0"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11858,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "pallet-ultraplonk-verifier"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11870,7 +11655,6 @@ dependencies = [
  "pallet-verifiers",
  "sp-core",
  "sp-io",
- "sp-std",
  "ultraplonk-no-std",
 ]
 
@@ -11908,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "pallet-verifiers"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11922,13 +11706,12 @@ dependencies = [
  "sp-core",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
 name = "pallet-verifiers-macros"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -11985,9 +11768,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "18.1.1"
+version = "18.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c70b60f0a76bcca27686889da513b2e1440979d0192cc34c738e75112c88c0"
+checksum = "dcdae3a410899ed12e605196ed3a43902dd22b07e8a815c7d47ff0f28bafbb9b"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -12389,21 +12172,6 @@ dependencies = [
  "fixedbitset 0.5.7",
  "indexmap 2.9.0",
 ]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher 1.0.1",
-]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -13283,7 +13051,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.4.2"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 
 [[package]]
 name = "polkadot-overseer"
@@ -14089,7 +13857,6 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
  "serde",
 ]
 
@@ -14114,7 +13881,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -14154,12 +13921,6 @@ dependencies = [
  "sp-crypto-hashing",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -14399,76 +14160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proof-of-sql"
-version = "0.28.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebb98863a7bf22a17fa8b6f3ad19b9bfc484921ea7d7bb522b262732acd00c1"
-dependencies = [
- "ahash",
- "ark-bls12-381",
- "ark-curve25519",
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "bigdecimal",
- "bit-iter",
- "blake3",
- "bumpalo",
- "byte-slice-cast",
- "bytemuck",
- "chrono",
- "curve25519-dalek",
- "derive_more 0.99.20",
- "indexmap 2.9.0",
- "itertools 0.13.0",
- "num-bigint",
- "num-traits",
- "postcard",
- "proof-of-sql-parser",
- "serde",
- "serde_json",
- "snafu 0.8.6",
- "tiny-keccak",
- "tracing",
- "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "proof-of-sql-parser"
-version = "0.28.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab33b18cc7296b8bc4fa0d15cd9db884b2994410237309e696ef641e5f0a50c"
-dependencies = [
- "arrayvec 0.7.6",
- "bigdecimal",
- "chrono",
- "lalrpop",
- "lalrpop-util",
- "serde",
- "snafu 0.8.6",
-]
-
-[[package]]
-name = "proof-of-sql-verifier"
-version = "0.1.0"
-source = "git+https://github.com/zkVerify/proof-of-sql-verifier.git?tag=v0.2.0#d499c6d64915954c033d14dbd2ec937434b8b564"
-dependencies = [
- "ahash",
- "ark-bls12-381",
- "ark-ec 0.4.2",
- "ark-serialize 0.4.2",
- "ciborium",
- "indexmap 2.9.0",
- "proof-of-sql",
- "proof-of-sql-parser",
- "serde",
- "serde_with",
- "snafu 0.8.6",
-]
-
-[[package]]
 name = "proptest"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14514,12 +14205,12 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.13.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost 0.13.5",
  "prost-types",
@@ -14548,7 +14239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -14608,24 +14299,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
 dependencies = [
- "asynchronous-codec 0.6.2",
+ "asynchronous-codec",
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
  "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "quick-protobuf-codec"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
-dependencies = [
- "asynchronous-codec 0.7.0",
- "bytes",
- "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -14729,7 +14407,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15192,7 +14870,7 @@ dependencies = [
 [[package]]
 name = "risc0-derive"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15201,8 +14879,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-verifier"
-version = "0.6.0"
-source = "git+https://github.com/zkVerify/risc0-verifier.git?tag=v0.6.0#5f658527cdeb53199c9dd694d84a03b8526b7d27"
+version = "0.7.0"
+source = "git+https://github.com/zkVerify/risc0-verifier.git?tag=v0.7.0#968365aa398c5fad0f94be15320202cc36455675"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -15625,7 +15303,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15638,7 +15316,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15786,7 +15464,7 @@ dependencies = [
  "security-framework 3.2.0",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16035,9 +15713,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.50.1"
+version = "0.50.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "792411fa02396d2fa8d932b92d4a2e936ef1c670a427820deb2832d75a2e7e4a"
+checksum = "57edff640006631f2d7461aa67f4ed70417d68b9f5470bc24dd4be7d8f84b892"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -16578,14 +16256,14 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.48.4"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4337c3707ea575ec354656ee7847eafe73432af2c07c944f609a83285eee66"
+checksum = "08dfb31dee4500a942a5cca23fa61f131fc648cf83c4258bed8b74d349ab77d9"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
- "asynchronous-codec 0.6.2",
+ "asynchronous-codec",
  "bytes",
  "cid 0.9.0",
  "either",
@@ -16748,15 +16426,13 @@ dependencies = [
 
 [[package]]
 name = "sc-network-types"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "149445bdb01a539d50d560468407a9a927938949b115ff5fd0cd04cca9349f42"
+checksum = "5432f4f7d0b9608be6650cb35c04dd8db3a982ce63fb643df974e2ec088dccda"
 dependencies = [
  "bs58",
- "bytes",
  "ed25519-dalek",
  "libp2p-identity",
- "libp2p-kad 0.46.2",
  "litep2p",
  "log",
  "multiaddr 0.18.2",
@@ -16768,9 +16444,9 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e0b1ad78caf4b34d4acbb3dbe4d13fbbdaafcf8cbed26766e028ac7393275"
+checksum = "bf2f9353ac3c9f5b6ded20ae15c8ca5794cb4236ac2f2f683304170a937da6b5"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -17640,8 +17316,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -18119,7 +17793,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -19701,18 +19375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot 0.12.4",
- "phf_shared",
- "precomputed-hash",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20199,16 +19861,6 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "term"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a984c8d058c627faaf5e8e2ed493fa3c51771889196de1016cf9c1c6e90d750"
-dependencies = [
- "home",
  "windows-sys 0.59.0",
 ]
 
@@ -21018,7 +20670,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 dependencies = [
- "asynchronous-codec 0.6.2",
+ "asynchronous-codec",
  "bytes",
  "futures-io",
  "futures-util",
@@ -21113,7 +20765,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vk-hash"
 version = "0.1.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "hp-groth16",
  "hp-verifiers",
@@ -21121,7 +20773,6 @@ dependencies = [
  "pallet-fflonk-verifier",
  "pallet-groth16-verifier",
  "pallet-plonky2-verifier",
- "pallet-proofofsql-verifier",
  "pallet-ultraplonk-verifier",
  "parity-scale-codec",
  "serde",
@@ -21863,7 +21514,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -22561,32 +22212,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -22677,7 +22307,7 @@ dependencies = [
 [[package]]
 name = "zkv-benchmarks"
 version = "11.0.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "sc-sysinfo",
  "serde_json",
@@ -22686,7 +22316,7 @@ dependencies = [
 [[package]]
 name = "zkv-cli"
 version = "11.0.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "cfg-if",
  "clap",
@@ -22874,8 +22504,8 @@ dependencies = [
 
 [[package]]
 name = "zkv-runtime"
-version = "0.14.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+version = "0.16.0"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "aggregate-rpc-runtime-api",
  "anyhow",
@@ -22918,7 +22548,6 @@ dependencies = [
  "pallet-offences",
  "pallet-plonky2-verifier",
  "pallet-preimage",
- "pallet-proofofsql-verifier",
  "pallet-proxy",
  "pallet-referenda",
  "pallet-risc0-verifier",
@@ -22959,7 +22588,6 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std",
  "sp-storage",
  "sp-transaction-pool",
  "sp-version",
@@ -22975,7 +22603,7 @@ dependencies = [
 [[package]]
 name = "zkv-service"
 version = "11.0.0"
-source = "git+https://github.com/zkVerify/zkVerify.git?branch=dr%2Fstable2412#7700a792f8f078591e745916bf03733dcc95dd8e"
+source = "git+https://github.com/zkVerify/zkVerify.git?tag=0.9.2-0.16.0#62f960fbbcc98bfd8f32ebb2203fc03a28e60a0f"
 dependencies = [
  "aggregate-rpc",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,19 +64,19 @@ pallet-transaction-payment-rpc-runtime-api = { version = "39.0.0", default-featu
 pallet-utility = { version = "39.1.0", default-features = false }
 sc-basic-authorship = { version = "0.48.0", default-features = false }
 sc-chain-spec = { version = "41.0.0", default-features = false }
-sc-cli = { version = "0.50.1", default-features = false }
+sc-cli = { version = "0.50.2", default-features = false }
 sc-client-api = { version = "38.0.0", default-features = false }
 sc-consensus = { version = "0.47.0", default-features = false }
 sc-consensus-aura = { version = "0.48.0", default-features = false }
 sc-consensus-manual-seal = { version = "0.49.0", default-features = false }
 sc-executor = { version = "0.41.0", default-features = false }
-sc-network = { version = "0.48.4", default-features = false }
+sc-network = { version = "0.48.5", default-features = false }
 sc-network-sync = { version = "0.47.0", default-features = false }
-sc-offchain = { version = "43.0.0", default-features = false }
+sc-offchain = { version = "43.0.1", default-features = false }
 sc-rpc = { version = "43.0.0", default-features = false }
 sc-service = { version = "0.49.0", default-features = false }
 sc-sysinfo = { version = "41.0.0", default-features = false }
-sc-telemetry = { version = "28.1.0", default-features = false }
+sc-telemetry = { version = "28.0.0", default-features = false }
 sc-tracing = { version = "38.0.0", default-features = false }
 sc-transaction-pool = { version = "38.1.0", default-features = false }
 sc-transaction-pool-api = { version = "38.1.0", default-features = false }
@@ -106,9 +106,9 @@ substrate-prometheus-endpoint = { version = "0.17.1", default-features = false }
 substrate-wasm-builder = { version = "25.0.1" }
 
 # Polkadot
-pallet-xcm = { version = "18.1.1", default-features = false }
-pallet-xcm-benchmarks = {version = "18.1.1", default-features = false}
-polkadot-cli = {package = "zkv-cli", git = "https://github.com/zkVerify/zkVerify", branch = "dr/stable2412"}
+pallet-xcm = { version = "18.1.2", default-features = false }
+pallet-xcm-benchmarks = { version = "18.1.1", default-features = false }
+polkadot-cli = {package = "zkv-cli", git = "https://github.com/zkVerify/zkVerify", tag = "0.9.2-0.16.0"}
 polkadot-primitives = { version = "17.1.0", default-features = false }
 polkadot-runtime-common = { version = "18.1.0", default-features = false }
 xcm = { version = "15.1.0", package = "staging-xcm", default-features = false }
@@ -118,7 +118,7 @@ xcm-executor = { version = "18.0.3", package = "staging-xcm-executor", default-f
 # Cumulus
 cumulus-client-cli = { version = "0.21.1", default-features = false }
 cumulus-client-collator = { version = "0.21.0", default-features = false }
-cumulus-client-consensus-aura = { version = "0.21.0", default-features = false }
+cumulus-client-consensus-aura = { version = "0.21.1", default-features = false }
 cumulus-client-consensus-common = { version = "0.21.0", default-features = false }
 cumulus-client-consensus-proposer = { version = "0.17.0", default-features = false }
 cumulus-client-service = { version = "0.22.0", default-features = false }
@@ -177,14 +177,14 @@ tokio = {version = "1.13"}
 ignored = ["num_enum"]
 
 [patch.crates-io]
-cumulus-relay-chain-inprocess-interface = {git = "https://github.com/zkVerify/zkVerify.git", branch = "dr/stable2412"}
-cumulus-relay-chain-minimal-node = {git = "https://github.com/zkVerify/zkVerify.git", branch = "dr/stable2412"}
-polkadot-omni-node-lib = {git = "https://github.com/zkVerify/zkVerify.git", branch = "dr/stable2412"}
+cumulus-relay-chain-inprocess-interface = {git = "https://github.com/zkVerify/zkVerify.git", tag = "0.9.2-0.16.0"}
+cumulus-relay-chain-minimal-node = {git = "https://github.com/zkVerify/zkVerify.git", tag = "0.9.2-0.16.0"}
+polkadot-omni-node-lib = {git = "https://github.com/zkVerify/zkVerify.git", tag = "0.9.2-0.16.0"}
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
 sc-block-builder = { version = "0.43.0" }
 sc-chain-spec = { version = "41.0.0" }
-sc-cli = { version = "0.50.1" }
+sc-cli = { version = "0.50.2" }
 sc-client-api = { version = "38.0.0" }
 sc-client-db = { version = "0.45.1" }
 sc-consensus = { version = "0.47.0" }
@@ -193,10 +193,10 @@ sc-consensus-grandpa = { version = "0.33.0" }
 sc-consensus-manual-seal = { version = "0.49.0" }
 sc-executor = { version = "0.41.0" }
 sc-keystore = { version = "34.0.0" }
-sc-network = { version = "0.48.4" }
+sc-network = { version = "0.48.5" }
 sc-network-common = { version = "0.47.0" }
 sc-network-sync = { version = "0.47.0" }
-sc-offchain = { version = "43.0.0" }
+sc-offchain = { version = "43.0.1" }
 sc-rpc = { version = "43.0.0" }
 sc-rpc-api = { version = "0.47.0" }
 sc-service = { version = "0.49.0" }
@@ -280,7 +280,7 @@ polkadot-runtime-common = { version = "18.1.0" }
 #pallet-election-provider-multi-phase = { version = "38.2.0" }
 sc-block-builder = { version = "0.43.0" }
 sc-chain-spec = { version = "41.0.0" }
-sc-cli = { version = "0.50.1" }
+sc-cli = { version = "0.50.2" }
 sc-client-api = { version = "38.0.0" }
 sc-client-db = { version = "0.45.1" }
 sc-consensus = { version = "0.47.0" }
@@ -289,10 +289,10 @@ sc-consensus-grandpa = { version = "0.33.0" }
 sc-consensus-manual-seal = { version = "0.49.0" }
 sc-executor = { version = "0.41.0" }
 sc-keystore = { version = "34.0.0" }
-sc-network = { version = "0.48.4" }
+sc-network = { version = "0.48.5" }
 sc-network-common = { version = "0.47.0" }
 sc-network-sync = { version = "0.47.0" }
-sc-offchain = { version = "43.0.0" }
+sc-offchain = { version = "43.0.1" }
 sc-rpc = { version = "43.0.0" }
 sc-rpc-api = { version = "0.47.0" }
 sc-service = { version = "0.49.0" }


### PR DESCRIPTION
zkVerify is now using tag 0.9.2-0.16.0, while Polkadot is at 2412-7.