### PR TITLE
Removed bootnodes sub domain and bump node version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22374,7 +22374,7 @@ dependencies = [
 
 [[package]]
 name = "zkv-para-evm-node"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zkv-para-evm-node"
-version = "0.2.0"
+version = "0.2.1"
 description = "zkVerify EVM Parachain Node"
 authors.workspace = true
 edition.workspace = true

--- a/node/chain-specs/zkverify_evm_vflow.json
+++ b/node/chain-specs/zkverify_evm_vflow.json
@@ -3,12 +3,12 @@
   "id": "vflow_testnet",
   "chainType": "Live",
   "bootNodes": [
-    "/dns/boot-node-tn-vflow-1.de.zkverify.io/tcp/30333/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
-    "/dns/boot-node-tn-vflow-1.de.zkverify.io/tcp/30334/ws/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
-    "/dns/boot-node-tn-vflow-1.de.zkverify.io/tcp/443/wss/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
-    "/dns/boot-node-tn-vflow-2.eu-west-gra.zkverify.io/tcp/30333/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84",
-    "/dns/boot-node-tn-vflow-2.eu-west-gra.zkverify.io/tcp/30334/ws/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84",
-    "/dns/boot-node-tn-vflow-2.eu-west-gra.zkverify.io/tcp/443/wss/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84"
+    "/dns/boot-node-tn-vflow-1.zkverify.io/tcp/30333/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
+    "/dns/boot-node-tn-vflow-1.zkverify.io/tcp/30334/ws/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
+    "/dns/boot-node-tn-vflow-1.zkverify.io/tcp/443/wss/p2p/12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim",
+    "/dns/boot-node-tn-vflow-2.zkverify.io/tcp/30333/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84",
+    "/dns/boot-node-tn-vflow-2.zkverify.io/tcp/30334/ws/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84",
+    "/dns/boot-node-tn-vflow-2.zkverify.io/tcp/443/wss/p2p/12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84"
   ],
   "telemetryEndpoints": [
     [

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -102,9 +102,9 @@ fn boot_node_address(dns: &str, peer_id: &str) -> impl Iterator<Item = Multiaddr
 
 pub fn testnet_config() -> Result<ChainSpec, String> {
     // The connection strings for bootnodes
-    const BOOTNODE_1_DNS: &str = "boot-node-tn-vflow-1.de.zkverify.io";
+    const BOOTNODE_1_DNS: &str = "boot-node-tn-vflow-1.zkverify.io";
     const BOOTNODE_1_PEER_ID: &str = "12D3KooWStRw5P6v8bydm3RjzsdSE75PNoFtCzZ5PnV1hkntWGim";
-    const BOOTNODE_2_DNS: &str = "boot-node-tn-vflow-2.eu-west-gra.zkverify.io";
+    const BOOTNODE_2_DNS: &str = "boot-node-tn-vflow-2.zkverify.io";
     const BOOTNODE_2_PEER_ID: &str = "12D3KooWFVarmg1RGuCnEsHVjYSxKd6idJ6cCEowkKkgaBPovt84";
 
     Ok(ChainSpec::builder(


### PR DESCRIPTION
Just some check in order to be sure that PR will not change the genesis

```sh
mdamico@miklap:~/devel/zkVerify-EVM-Parachain$ ./target/release/zkv-para-evm-node 
2025-07-22 10:49:42 zkVerify EVM Parachain    
2025-07-22 10:49:42 ✌️  version 0.2.1-71e37e70f45    
2025-07-22 10:49:42 ❤️  by Horizen Labs <admin@horizenlabs.io>, 2024-2025    
2025-07-22 10:49:42 📋 Chain specification: VFlow Testnet    
2025-07-22 10:49:42 🏷  Node name: pumped-cherry-1393    
2025-07-22 10:49:42 👤 Role: FULL    
2025-07-22 10:49:42 💾 Database: RocksDb at /home/mdamico/.local/share/zkv-para-evm-node/chains/vflow_testnet/db/full    
2025-07-22 10:49:44 Parachain Id: 1    
2025-07-22 10:49:44 Parachain Account: 5Ec4AhNmTPsRSiBHeyHEMojCJFbKn7aoT3KNKnQEc3gV3ocB    
2025-07-22 10:49:44 Is collating: no    
2025-07-22 10:49:45 [Parachain] 🔨 Initializing Genesis block/state (state: 0x69e0…0ce7, header-hash: 0x206d…857f)    
2025-07-22 10:49:45 [Parachain]  creating SingleState txpool Limit { count: 8192, total_bytes: 20971520 }/Limit { count: 819, total_bytes: 2097152 }.    
2025-07-22 10:50:11 [Relaychain]  creating SingleState txpool Limit { count: 8192, total_bytes: 20971520 }/Limit { count: 819, total_bytes: 2097152 }.    
2025-07-22 10:50:12 [Relaychain] 🏷  Local node identity is: 12D3KooWBP6UV99zMHRjQTfhmEbptv3x7JErP1p4wDTPNPXe9SG4    
2025-07-22 10:50:12 [Relaychain] Running libp2p network backend    
2025-07-22 10:50:12 [Relaychain] 💻 Operating system: linux    
2025-07-22 10:50:12 [Relaychain] 💻 CPU architecture: x86_64    
2025-07-22 10:50:12 [Relaychain] 💻 Target environment: gnu    
2025-07-22 10:50:12 [Relaychain] 💻 CPU: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz    
2025-07-22 10:50:12 [Relaychain] 💻 CPU cores: 8    
2025-07-22 10:50:12 [Relaychain] 💻 Memory: 62723MB    
2025-07-22 10:50:12 [Relaychain] 💻 Kernel: 6.14.0-24-generic    
2025-07-22 10:50:12 [Relaychain] 💻 Linux distribution: Ubuntu 25.04    
2025-07-22 10:50:12 [Relaychain] 💻 Virtual machine: no    
2025-07-22 10:50:12 [Relaychain] 📦 Highest known block at #89461    
2025-07-22 10:50:12 [Relaychain] 〽️ Prometheus exporter started at 127.0.0.1:9616    
2025-07-22 10:50:12 [Relaychain] Running JSON-RPC server: addr=127.0.0.1:9945,[::1]:9945    
2025-07-22 10:50:12 [Relaychain] 🏁 CPU single core score: 677.48 MiBs, parallelism score: 930.17 MiBs with expected cores: 8    
2025-07-22 10:50:12 [Relaychain] 🏁 Memory score: 12.19 GiBs    
2025-07-22 10:50:12 [Relaychain] 🏁 Disk score (seq. writes): 1.54 GiBs    
2025-07-22 10:50:12 [Relaychain] 🏁 Disk score (rand. writes): 647.57 MiBs    
2025-07-22 10:50:12 [Parachain] 🏷  Local node identity is: 12D3KooWAAMWRDuw9ou77j2TDssiGGH7E1VqthyJuE6QYsk2vxK6    
2025-07-22 10:50:12 [Parachain] Running libp2p network backend    
2025-07-22 10:50:12 [Parachain] 💻 Operating system: linux    
2025-07-22 10:50:12 [Parachain] 💻 CPU architecture: x86_64    
2025-07-22 10:50:12 [Parachain] 💻 Target environment: gnu    
2025-07-22 10:50:12 [Parachain] 💻 CPU: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz    
2025-07-22 10:50:12 [Parachain] 💻 CPU cores: 8    
2025-07-22 10:50:12 [Parachain] 💻 Memory: 62723MB    
2025-07-22 10:50:12 [Parachain] 💻 Kernel: 6.14.0-24-generic    
2025-07-22 10:50:12 [Parachain] 💻 Linux distribution: Ubuntu 25.04    
2025-07-22 10:50:12 [Parachain] 💻 Virtual machine: no    
2025-07-22 10:50:12 [Parachain] 📦 Highest known block at #0    
2025-07-22 10:50:12 [Parachain] 〽️ Prometheus exporter started at 127.0.0.1:9615    
2025-07-22 10:50:12 [Parachain] Running JSON-RPC server: addr=127.0.0.1:9944,[::1]:9944    
2025-07-22 10:50:12 [Parachain] 🏁 CPU single core score: 677.48 MiBs, parallelism score: 930.17 MiBs with expected cores: 8    
2025-07-22 10:50:12 [Parachain] 🏁 Memory score: 12.19 GiBs    
2025-07-22 10:50:12 [Parachain] 🏁 Disk score (seq. writes): 1.54 GiBs    
2025-07-22 10:50:12 [Parachain] 🏁 Disk score (rand. writes): 647.57 MiBs    
2025-07-22 10:50:12 [Parachain] discovered: 12D3KooWBP6UV99zMHRjQTfhmEbptv3x7JErP1p4wDTPNPXe9SG4 /ip4/10.17.60.11/tcp/30334/ws    
2025-07-22 10:50:12 [Relaychain] discovered: 12D3KooWAAMWRDuw9ou77j2TDssiGGH7E1VqthyJuE6QYsk2vxK6 /ip4/172.17.0.1/tcp/30333/ws    
2025-07-22 10:50:12 [Parachain] discovered: 12D3KooWBP6UV99zMHRjQTfhmEbptv3x7JErP1p4wDTPNPXe9SG4 /ip4/172.18.0.1/tcp/30334/ws    
2025-07-22 10:50:12 [Relaychain] discovered: 12D3KooWAAMWRDuw9ou77j2TDssiGGH7E1VqthyJuE6QYsk2vxK6 /ip4/172.18.0.1/tcp/30333/ws    
2025-07-22 10:50:12 [Relaychain] discovered: 12D3KooWAAMWRDuw9ou77j2TDssiGGH7E1VqthyJuE6QYsk2vxK6 /ip4/10.17.60.11/tcp/30333/ws    
2025-07-22 10:50:12 [Parachain] discovered: 12D3KooWBP6UV99zMHRjQTfhmEbptv3x7JErP1p4wDTPNPXe9SG4 /ip4/172.17.0.1/tcp/30334/ws    
2025-07-22 10:50:13 [Relaychain] 🔍 Discovered new external address for our node: /ip4/87.241.3.130/tcp/30334/ws/p2p/12D3KooWBP6UV99zMHRjQTfhmEbptv3x7JErP1p4wDTPNPXe9SG4    
2025-07-22 10:50:13 [Parachain] 🔍 Discovered new external address for our node: /ip4/87.241.3.130/tcp/30333/ws/p2p/12D3KooWAAMWRDuw9ou77j2TDssiGGH7E1VqthyJuE6QYsk2vxK6    
2025-07-22 10:50:17 [Relaychain] ⚙️  Syncing, target=#1623233 (8 peers), best: #90704 (0xbcad…9689), finalized #90624 (0x02a1…db89), ⬇ 1.3MiB/s ⬆ 23.6kiB/s    
2025-07-22 10:50:17 [Parachain] ⚙️  Syncing, target=#6387 (9 peers), best: #2719 (0xcf45…f3a5), finalized #0 (0x206d…857f), ⬇ 3.8MiB/s ⬆ 5.4kiB/s    
2025-07-22 10:50:19 [Parachain] assembling new collators for new session 2 at #3600    
2025-07-22 10:50:22 [Relaychain] ⚙️  Syncing 381.6 bps, target=#1623234 (8 peers), best: #92612 (0xe8a5…f2ab), finalized #92160 (0xc9ea…ea88), ⬇ 532.3kiB/s ⬆ 3.3kiB/s    
2025-07-22 10:50:22 [Parachain] ⚙️  Preparing 518.0 bps, target=#6388 (9 peers), best: #5309 (0xb66f…a388), finalized #0 (0x206d…857f), ⬇ 1.6MiB/s ⬆ 0.8kiB/s    
2025-07-22 10:50:23 [Relaychain] [92904] 💸 generated 10 npos voters, 7 from validators and 3 nominators    
2025-07-22 10:50:23 [Relaychain] [92904] 💸 generated 7 npos targets    
2025-07-22 10:50:23 [Relaychain] [92904] 💸 new validator set of size 7 has been processed for era 27    
2025-07-22 10:50:25 [Parachain] 💔 Error importing block 0x396f2f8d7addb47db7e87f3209c097ebec82973811cd0764ba403048ba0186f6: block has an unknown parent    
2025-07-22 10:50:25 [Parachain] 🆕 Imported #6388 (0x965e…c5c8 → 0x8c8e…cbcf)    
2025-07-22 10:50:25 [Parachain] 🏆 Imported #6389 (0x8c8e…cbcf → 0x396f…86f6)    
2025-07-22 10:50:27 [Relaychain] ⚙️  Syncing 412.4 bps, target=#1623235 (8 peers), best: #94674 (0x9fcb…bae7), finalized #94208 (0xc2e0…aa57), ⬇ 563.6kiB/s ⬆ 3.6kiB/s    
2025-07-22 10:50:27 [Parachain] 💤 Idle (9 peers), best: #6389 (0x396f…86f6), finalized #0 (0x206d…857f), ⬇ 10.7kiB/s ⬆ 0.7kiB/s    
2025-07-22 10:50:30 [Parachain] 🏆 Imported #6390 (0x396f…86f6 → 0x7830…3535)    
2025-07-22 10:50:32 [Relaychain] [96504] 💸 generated 10 npos voters, 7 from validators and 3 nominators    
2025-07-22 10:50:32 [Relaychain] [96504] 💸 generated 7 npos targets    
2025-07-22 10:50:32 [Relaychain] [96504] 💸 new validator set of size 7 has been processed for era 28    
2025-07-22 10:50:32 [Relaychain] ⚙️  Syncing 397.2 bps, target=#1623236 (8 peers), best: #96660 (0x329c…7dc9), finalized #96256 (0x4fb6…f3fd), ⬇ 687.5kiB/s ⬆ 1.4kiB/s    
2025-07-22 10:50:32 [Parachain] 💤 Idle (9 peers), best: #6390 (0x7830…3535), finalized #0 (0x206d…857f), ⬇ 9.4kiB/s ⬆ 1.0kiB/s    
2025-07-22 10:50:36 [Parachain] 🏆 Imported #6391 (0x7830…3535 → 0x8d16…4e10)    
2025-07-22 10:50:37 [Relaychain] ⚙️  Syncing 373.6 bps, target=#1623237 (8 peers), best: #98528 (0x8bbc…2cbe), finalized #98304 (0x3373…7f65), ⬇ 1.7MiB/s ⬆ 0.7kiB/s    
2025-07-22 10:50:37 [Parachain] 💤 Idle (9 peers), best: #6391 (0x8d16…4e10), finalized #0 (0x206d…857f), ⬇ 7.8kiB/s ⬆ 0.9kiB/s    
2025-07-22 10:50:42 [Parachain] 🏆 Imported #6392 (0x8d16…4e10 → 0xa828…c6fe)    
2025-07-22 10:50:42 [Relaychain] ⚙️  Syncing 200.8 bps, target=#1623238 (8 peers), best: #99532 (0xf9de…db48), finalized #99328 (0x3bff…80aa), ⬇ 485.3kiB/s ⬆ 0.8kiB/s    
2025-07-22 10:50:42 [Parachain] 💤 Idle (9 peers), best: #6392 (0xa828…c6fe), finalized #0 (0x206d…857f), ⬇ 8.6kiB/s ⬆ 0.2kiB/s    
2025-07-22 10:50:44 [Relaychain] [100104] 💸 generated 10 npos voters, 7 from validators and 3 nominators    
2025-07-22 10:50:44 [Relaychain] [100104] 💸 generated 7 npos targets    
2025-07-22 10:50:44 [Relaychain] [100104] 💸 new validator set of size 7 has been processed for era 29    
2025-07-22 10:50:47 [Relaychain] ⚙️  Syncing 358.2 bps, target=#1623238 (8 peers), best: #101323 (0xb20d…75ef), finalized #100864 (0x8d6f…8ea3), ⬇ 1.0MiB/s ⬆ 3.2kiB/s    
2025-07-22 10:50:47 [Parachain] 💤 Idle (9 peers), best: #6392 (0xa828…c6fe), finalized #0 (0x206d…857f), ⬇ 1.7kiB/s ⬆ 0.5kiB/s    
2025-07-22 10:50:48 [Parachain] 🏆 Imported #6393 (0xa828…c6fe → 0x10ed…3b6e)    
^Cmdamico@miklap:~/devel/zkVerify-EVM-Parachain$ ./target/release/zkv-para-evm-node export-genesis-state --chain test > ./para-genesis-state
2025-07-22 10:52:28 🔨 Initializing Genesis block/state (state: 0x69e0…0ce7, header-hash: 0x206d…857f)    
2025-07-22 10:52:28  creating SingleState txpool Limit { count: 8192, total_bytes: 20971520 }/Limit { count: 512, total_bytes: 1048576 }.    
mdamico@miklap:~/devel/zkVerify-EVM-Parachain$ diff ./para-genesis-state ../../para-genesis-state 
mdamico@miklap:~/devel/zkVerify-EVM-Parachain$ ./target/release/zkv-para-evm-node export-genesis-wasm --chain test > ./para-genesis.wasm
mdamico@miklap:~/devel/zkVerify-EVM-Parachain$ diff ./para-genesis.wasm ../../para-genesis.wasm 
mdamico@miklap:~/devel/zkVerify-EVM-Parachain$ 
```
I used it to connet to volta and check that produce the same genesis and wasm that I used yesterday to register the parachain