### PR TITLE
Download RELAY chain spec file

### DIFF
--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -275,6 +275,11 @@ unset EVM_NODE_KEY
 ####
 # Relaychain collator's configuration (env->arg)
 ####
+if [ "${DEV_MODE:-false}" != "true" ]; then
+  # Call the function for EVM_CONF_CHAIN
+  validate_and_download "ZKV_CONF_CHAIN" "ZKV_SPEC_FILE_URL"
+fi
+
 prefix="ZKV_CONF_"
 if env | grep -q "^${prefix}"; then
   log_bold_green "=== Relaychain node's configuration:"


### PR DESCRIPTION
When starting Parachain using spec file, relay chain spec file needs to be downloaded as well otherwise node will refuse to start.
> This will enforce check on **ZKV_CONF_CHAIN** to be always set when starting the node which should not be an issue