### PR TITLE
Update conversion for local 32B accounts

### DIFF
--- a/runtime/vflow/src/configs/xcm.rs
+++ b/runtime/vflow/src/configs/xcm.rs
@@ -86,18 +86,17 @@ pub type LocationToAccountId = (
 pub struct LocationAccountId32ToAccountId;
 impl ConvertLocation<AccountId> for LocationAccountId32ToAccountId {
     fn convert_location(location: &Location) -> Option<AccountId> {
-        use xcm::latest::Junctions::X1;
         match location.unpack() {
+            // VFlow does not have 32 byte accounts locally; convert this as if it is representing
+            // the relay chain (picked up by HashedDescription)
             (0, [AccountId32 { network, id }]) => {
-                LocationToAccountId::convert_location(&Location {
-                    parents: 0,
-                    interior: X1(sp_std::sync::Arc::new([AccountKey20 {
+                LocationToAccountId::convert_location(&Location::new(
+                    1, // treat it as representing a relay chain address
+                    [AccountId32 {
                         network: *network,
-                        key: id.as_slice()[id.len() - 20..] // take the last 20 bytes
-                            .try_into()
-                            .expect("Cannot convert AccountId32 to AccountKey20"),
-                    }])),
-                })
+                        id: *id,
+                    }],
+                ))
             }
             _ => LocationToAccountId::convert_location(location),
         }

--- a/runtime/vflow/src/tests/xcm_runtime_apis_impl.rs
+++ b/runtime/vflow/src/tests/xcm_runtime_apis_impl.rs
@@ -173,7 +173,10 @@ mod convert_location {
     }
 
     #[rstest]
-    fn truncates_parachain_account_id_32_to_last_20_bytes(alice_account_id_32: [u8; 32]) {
+    fn converts_local_account_id_32_to_20_bytes_projection(
+        alice_account_id_32: [u8; 32],
+        alice_account_key_20: [u8; 20],
+    ) {
         ExtBuilder::default().build().execute_with(|| {
             let location = RootLocation::get()
                 .pushed_with_interior(Junction::AccountId32 {
@@ -185,7 +188,7 @@ mod convert_location {
 
             assert_eq!(
                 Runtime::convert_location(location).unwrap(),
-                alice_account_id_32[12..].try_into().unwrap()
+                alice_account_key_20.into()
             );
         })
     }


### PR DESCRIPTION
This PR updates the xcm location conversion to handle local `AccountId32` that could be erroneously used by end users, as if they were representing relay chain remote origins.