### PR TITLE
ci: pass VERSION_STR to publish job and fix Slack Docker tag

### DIFF
--- a/.github/workflows/CI-release.yml
+++ b/.github/workflows/CI-release.yml
@@ -38,6 +38,7 @@ jobs:
       is-a-prod-release: ${{ steps.check-requirements.outputs.PROD_RELEASE }}
       is-a-rc-release: ${{ steps.check-requirements.outputs.RC_RELEASE }}
       is-a-test-release: ${{ steps.check-requirements.outputs.TEST_RELEASE }}
+      version-str: ${{ steps.check-requirements.outputs.VERSION_STR }}
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
@@ -57,6 +58,7 @@ jobs:
           echo "PROD_RELEASE=${PROD_RELEASE}" >> "${GITHUB_OUTPUT}"
           echo "RC_RELEASE=${RC_RELEASE}" >> "${GITHUB_OUTPUT}"
           echo "TEST_RELEASE=${TEST_RELEASE}" >> "${GITHUB_OUTPUT}"
+          echo "VERSION_STR=${VERSION_STR}" >> "${GITHUB_OUTPUT}"
 
   build-docker:
     runs-on: warp-ubuntu-latest-x64-8x
@@ -104,6 +106,7 @@ jobs:
           PROD_RELEASE: ${{ needs.check-requirements.outputs.is-a-prod-release }}
           RC_RELEASE: ${{ needs.check-requirements.outputs.is-a-rc-release }}
           TEST_RELEASE: ${{ needs.check-requirements.outputs.is-a-test-release }}
+          VERSION_STR: ${{ needs.check-requirements.outputs.version-str }}
         shell: bash
         run: |
           "${GITHUB_WORKSPACE}/ci/publish-docker-image.sh" --image-artifact ${{ needs.build-docker.outputs.artifact_name }}
@@ -162,7 +165,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Docker Image Tag:*  <https://hub.docker.com/r/${{ env.DOCKER_HUB_ORG }}/${{ env.DOCKER_IMAGE_BUILD_NAME }}/tags?page=1&name=${{ github.ref_name }}| ${{ github.ref_name }}>\n"
+                      "text": "*Docker Image Tag:*  <https://hub.docker.com/r/${{ env.DOCKER_HUB_ORG }}/${{ env.DOCKER_IMAGE_BUILD_NAME }}/tags?page=1&name=${{ needs.check-requirements.outputs.version-str }}| ${{ needs.check-requirements.outputs.version-str }}>\n"
                     },
                     {
                       "type": "mrkdwn",
@@ -174,7 +177,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "```docker pull ${{ env.DOCKER_HUB_ORG }}/${{ env.DOCKER_IMAGE_BUILD_NAME }}:${{ github.ref_name }}```"
+                    "text": "```docker pull ${{ env.DOCKER_HUB_ORG }}/${{ env.DOCKER_IMAGE_BUILD_NAME }}:${{ needs.check-requirements.outputs.version-str }}```"
                   }
                 }
               ]


### PR DESCRIPTION
## Problem

The `v2.0.0-rc1` release failed at the Docker publish step:

```
Error parsing reference: "index.docker.io/***/vflow-node:" is not a valid repository/tag: invalid reference format
```

The tag after the colon was empty. `check_release_requirements.sh` computes `VERSION_STR` (the `v`-stripped tag, e.g. `2.0.0-rc1`) and correctly detected the RC release, but the workflow never exposed `VERSION_STR` as a job output nor forwarded it to the publish job. So `publish-docker-image.sh` read an empty `VERSION_STR`, producing an empty `docker_tag_full` and the `vflow-node:` reference.

## Fix

Mirror the zkVerify `CI-release.yml` wiring:

- Add `version-str` output to the `check-requirements` job.
- `echo "VERSION_STR=..." >> "$GITHUB_OUTPUT"` in the check step.
- Pass `VERSION_STR` into the `publish-docker-image` step env.

Also fix a related `v`-prefix mismatch in the Slack notification: the Docker Hub tag link and `docker pull` command used `github.ref_name` (`v2.0.0-rc1`), but the pushed image tag has no `v` (`2.0.0-rc1`). Both now use the `v`-stripped `version-str`, matching the actual image. The GitHub release `tag_name` intentionally keeps `github.ref_name` (the GitHub tag keeps the `v`).

## Result

`v2.0.0-rc1` now publishes as `vflow-node:2.0.0-rc1`, and the Slack `docker pull` command references a tag that actually exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)