### PR TITLE
Bump the frontier version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3636,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4274,9 +4274,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -3636,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4220,7 +4220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.18.2"
-source = "git+https://github.com/moonbeam-foundation/ethereum?branch=moonbeam-polkadot-stable2512#d7bdf2888253a30f160d434688e378636e253870"
+source = "git+https://github.com/moonbeam-foundation/ethereum?branch=moonbeam-polkadot-stable2512#58a5a8a1eeec58fa8a9ca8c6fab20a028ddcc1e5"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4476,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4506,8 +4506,9 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
+ "ethereum-types",
  "fc-db",
  "fc-storage",
  "fp-consensus",
@@ -4529,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4583,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4599,7 +4600,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4854,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4872,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4883,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "fp-dynamic-fee"
 version = "1.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "async-trait",
  "sp-core",
@@ -4893,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4905,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "environmental",
  "evm",
@@ -4921,7 +4922,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4937,7 +4938,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4949,7 +4950,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6533,7 +6534,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8432,7 +8433,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.1.3",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9234,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9282,7 +9283,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9307,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9355,7 +9356,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "fp-evm",
 ]
@@ -9363,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9373,7 +9374,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "fp-evm",
  "num",
@@ -9382,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9393,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -10362,16 +10363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset 0.4.2",
- "indexmap 2.13.0",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset 0.5.7",
  "indexmap 2.13.0",
 ]
 
@@ -11657,7 +11648,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "environmental",
  "evm",
@@ -11681,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#7396ae16c1d3ce1b61bd15978bd75e1e4969bf8c"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#54396433082b24b6e798df589d49a5172c0b9d35"
 dependencies = [
  "case",
  "num_enum 0.7.5",
@@ -11968,11 +11959,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.7.1",
+ "petgraph 0.6.5",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -11988,7 +11979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.4.1",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -12020,7 +12011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12033,7 +12024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12177,7 +12168,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13064,7 +13055,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -17039,7 +17030,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -18755,7 +18746,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/node/src/eth.rs
+++ b/node/src/eth.rs
@@ -185,6 +185,7 @@ pub async fn spawn_frontier_tasks(
     overrides: Arc<dyn StorageOverride<Block>>,
     fee_history_cache: FeeHistoryCache,
     fee_history_cache_limit: FeeHistoryCacheLimit,
+    state_pruning_blocks: Option<u64>,
     sync: Arc<SyncingService<Block>>,
     pubsub_notification_sinks: Arc<
         fc_mapping_sync::EthereumBlockNotificationSinks<
@@ -207,6 +208,7 @@ pub async fn spawn_frontier_tasks(
                     b.clone(),
                     3,
                     0,
+                    state_pruning_blocks,
                     fc_mapping_sync::SyncStrategy::Normal,
                     sync,
                     pubsub_notification_sinks,

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -426,6 +426,16 @@ where
         })
     };
 
+    // Derive state_pruning_blocks from the node's --state-pruning so the mapping-sync
+    // worker can skip past pruned blocks during catch-up (KV backend only).
+    let state_pruning_blocks = parachain_config.state_pruning.as_ref().and_then(|mode| {
+        if let sc_service::PruningMode::Constrained(c) = mode {
+            c.max_blocks.map(u64::from)
+        } else {
+            None
+        }
+    });
+
     sc_service::spawn_tasks(sc_service::SpawnTasksParams {
         rpc_builder,
         client: client.clone(),
@@ -503,6 +513,7 @@ where
         overrides,
         fee_history_cache,
         fee_history_cache_limit,
+        state_pruning_blocks,
         sync_service.clone(),
         pubsub_notification_sinks,
     )


### PR DESCRIPTION
The updated version includes [a patch](https://github.com/polkadot-evm/frontier/pull/1856) to fix the stuck response for `eth_getBlockByNumber` when invoked for "latest".